### PR TITLE
fix: arg name in example in var details

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Description: This object describes the public IP configuration when creating Nat
 
 ```hcl
 #Standard Regional IPV4 Public IP address configuration
-public_ip_configuration_details = {
+public_ip_configuration = {
   allocation_method       = "Static"
   ddos_protection_mode    = "VirtualNetworkInherited"
   idle_timeout_in_minutes = 30

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "public_ip_configuration" {
     sku                     = "Standard"
     zones                   = ["1", "2", "3"]
   }
-  description = <<PUBLIC_IP_CONFIGURATION_DETAILS
+  description = <<PUBLIC_IP_CONFIGURATION
 This object describes the public IP configuration when creating Nat Gateway's with a public IP.  If creating more than one public IP, then these values will be used for all public IPs.
 
 - `allocation_method`       = (Required) - Defines the allocation method for this IP address. Possible values are Static or Dynamic.
@@ -95,7 +95,7 @@ This object describes the public IP configuration when creating Nat Gateway's wi
 
 ```hcl
 #Standard Regional IPV4 Public IP address configuration
-public_ip_configuration_details = {
+public_ip_configuration = {
   allocation_method       = "Static"
   ddos_protection_mode    = "VirtualNetworkInherited"
   idle_timeout_in_minutes = 30
@@ -104,7 +104,7 @@ public_ip_configuration_details = {
   sku                     = "Standard"
 }
 ```
-PUBLIC_IP_CONFIGURATION_DETAILS
+PUBLIC_IP_CONFIGURATION
   nullable    = false
 }
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Fixes the name of module argument in variable description example from "public_ip_configuration_details" to "public_ip_configuration" to match the actual arg name.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
